### PR TITLE
スレッド招待可能ユーザーを相互フォローのみに

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -2,14 +2,12 @@ class RoomsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_user, only: [:new, :edit, :update]
   before_action :following_user, only: [:new, :create, :edit, :update]
+  before_action :follower, only: [:new, :edit]
 
   def new
     @thread = Room.new
     room_ids = current_user.rooms.ids
     @rooms = Room.where(id: room_ids)
-    followers = User.find(current_user.id).follower_ids
-    follower_users = User.where(id: followers)
-    @mutual_follow = @users && follower_users
   end
 
   def create
@@ -23,8 +21,8 @@ class RoomsController < ApplicationController
 
   def edit
     @users_in_this_room = @room.users
-    @follow_users = @users.where.not(id: @users_in_this_room.ids)
     @room = Room.find_by(public_uid: params[:id])
+    @invite_users = @mutual_follow - @users_in_this_room
   end
   
   def update
@@ -57,5 +55,11 @@ class RoomsController < ApplicationController
   def following_user
     followings = User.find(current_user.id).following_ids
     @users = User.where(id: followings)
+  end
+
+  def follower
+    followers = User.find(current_user.id).follower_ids
+    follower_users = User.where(id: followers)
+    @mutual_follow = @users && follower_users
   end
 end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -7,6 +7,9 @@ class RoomsController < ApplicationController
     @thread = Room.new
     room_ids = current_user.rooms.ids
     @rooms = Room.where(id: room_ids)
+    followers = User.find(current_user.id).follower_ids
+    follower_users = User.where(id: followers)
+    @mutual_follow = @users && follower_users
   end
 
   def create

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -5,7 +5,6 @@ class Room < ApplicationRecord
   has_many :watches, dependent: :destroy
 
   validates :thread_name, presence: true
-  validates :public_uid, presence: true, uniqueness: true
 
   generate_public_uid
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,6 @@ class User < ApplicationRecord
   
   validates :username, presence: true
   validates_format_of :email, with: EMAIL_REGEX
-  validates :public_uid, presence: true, uniqueness: true
 
   generate_public_uid
 

--- a/app/views/rooms/edit.html.erb
+++ b/app/views/rooms/edit.html.erb
@@ -24,14 +24,14 @@
 
       <div class="field-form-invite">
         <%= f.label :user_ids, "招待する", class: "label-name" %>
-        <% unless @follow_users == [] %>
-          <%= f.collection_check_boxes :user_ids, @follow_users, :id, :username, include_hidden: false do |user| %>
+        <% unless @invite_users == [] %>
+          <%= f.collection_check_boxes :user_ids, @invite_users, :id, :username, include_hidden: false do |user| %>
             <div class="users-list">
               <%= user.label { user.check_box + user.text } %>
             </div>
           <% end %>
         <% else %>
-          <p>ユーザーをフォローしてください</p>
+          <p>招待できるユーザーがいません</p>
         <% end %>
       </div>
       <div class="update-thread-info">

--- a/app/views/rooms/new.html.erb
+++ b/app/views/rooms/new.html.erb
@@ -16,7 +16,7 @@
         <%= f.label :user_ids, "招待する", class: "label-name" %>
         <% unless @users == [] %>
           <div class="users-lists">
-            <%= f.collection_check_boxes :user_ids, @users, :id, :username, include_hidden: false do |user| %>
+            <%= f.collection_check_boxes :user_ids, @mutual_follow, :id, :username, include_hidden: false do |user| %>
               <span class="users-list">
                 <%= user.label { user.check_box + user.text } %>
               </span>


### PR DESCRIPTION
# What
相互フォローユーザーのみをスレッドに招待可能

# Why
一方的なフォローのみで招待可能にしていると誰でも強制的にスレッドに招待できるため
プライバシー保護の観点から相互フォローのみに